### PR TITLE
Fixing the routing issue that prevents servers from provisioning

### DIFF
--- a/helper_scripts/oob-mgmt-server-netq-setup.sh
+++ b/helper_scripts/oob-mgmt-server-netq-setup.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 sudo su - cumulus -c '\
-git clone https://github.com/cumulusnetworks/netqdemo-1.0 netqdemo; \
+git clone https://github.com/rdarbha/netqdemo-1.0 netqdemo; \
 '

--- a/helper_scripts/oob-mgmt-server-provision.sh
+++ b/helper_scripts/oob-mgmt-server-provision.sh
@@ -5,4 +5,4 @@ sudo sh -c 'echo "deb http://repo3.cumulusnetworks.com/repo Jessie-supplemental 
 sudo apt-get update
 sudo apt-get install -yq git python-netaddr sshpass
 sudo apt-get install -yq -t jessie-backports ansible
-git clone https://github.com/CumulusNetworks/cldemo-provision-ts.git
+git clone https://github.com/rdarbha/cldemo-provision-ts.git

--- a/hostset.yml
+++ b/hostset.yml
@@ -83,7 +83,7 @@
         dest: /etc/network/interfaces
         marker: "# bond config"
         block: |
-          auto eth1 
+          auto eth1
           iface eth1 inet manual
              bond-master bond0
           #
@@ -103,8 +103,9 @@
              address {{ host_ip_addr|trim }}
              post-up ifenslave bond0 eth1 eth2
              post-up ip link set bond0 promisc on
-             post-up ip route replace default via {{ my_gw_ip | trim }} dev bond0
-      
+             post-up ip route add 10.0.0.0/8 via {{ my_gw_ip | trim }} dev bond0
+             #post-up ip route replace default via {{ my_gw_ip | trim }} dev bond0
+
       become: true
       when: "{{ dual_attach_hosts }}"
       tags:


### PR DESCRIPTION
The default route configuration on the server causes two issues:
1. With default route in post-up will cause apt to fail installing during ansible deployment
2. Without default route in post-up will cause server to fail ping after provisioning

I added a more specific post-up route to work around this problem.